### PR TITLE
Add delete commands for core topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,17 @@ Set the following environment variables before running the CLI (they are used as
 # Commands
 <!-- commands -->
 * [`ppls correspondents add NAME`](#ppls-correspondents-add-name)
+* [`ppls correspondents delete ID`](#ppls-correspondents-delete-id)
 * [`ppls correspondents list`](#ppls-correspondents-list)
 * [`ppls correspondents show ID`](#ppls-correspondents-show-id)
 * [`ppls correspondents update ID`](#ppls-correspondents-update-id)
 * [`ppls custom-fields add NAME`](#ppls-custom-fields-add-name)
+* [`ppls custom-fields delete ID`](#ppls-custom-fields-delete-id)
 * [`ppls custom-fields list`](#ppls-custom-fields-list)
 * [`ppls custom-fields show ID`](#ppls-custom-fields-show-id)
 * [`ppls custom-fields update ID`](#ppls-custom-fields-update-id)
 * [`ppls document-types add NAME`](#ppls-document-types-add-name)
+* [`ppls document-types delete ID`](#ppls-document-types-delete-id)
 * [`ppls document-types list`](#ppls-document-types-list)
 * [`ppls document-types show ID`](#ppls-document-types-show-id)
 * [`ppls document-types update ID`](#ppls-document-types-update-id)
@@ -54,6 +57,7 @@ Set the following environment variables before running the CLI (they are used as
 * [`ppls help [COMMAND]`](#ppls-help-command)
 * [`ppls profile`](#ppls-profile)
 * [`ppls tags add NAME`](#ppls-tags-add-name)
+* [`ppls tags delete ID`](#ppls-tags-delete-id)
 * [`ppls tags list`](#ppls-tags-list)
 * [`ppls tags show ID`](#ppls-tags-show-id)
 * [`ppls tags update ID`](#ppls-tags-update-id)
@@ -93,6 +97,42 @@ EXAMPLES
 ```
 
 _See code: [src/commands/correspondents/add.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/correspondents/add.ts)_
+
+## `ppls correspondents delete ID`
+
+Delete a correspondent
+
+```
+USAGE
+  $ ppls correspondents delete ID [--date-format <value>] [--header <value>...] [--hostname <value>] [--plain | --json |
+    --table] [--sort <value>] [--token <value>] [-y]
+
+ARGUMENTS
+  ID  Correspondent id
+
+FLAGS
+  -y, --yes           Skip confirmation prompt
+      --sort=<value>  Sort results by the provided field
+
+GLOBAL FLAGS
+  --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
+  --json                 Format output as json.
+  --plain                Format output as plain text.
+  --table                Format output as table.
+
+ENVIRONMENT FLAGS
+  --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
+  --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
+  --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+DESCRIPTION
+  Delete a correspondent
+
+EXAMPLES
+  $ ppls correspondents delete 123
+```
+
+_See code: [src/commands/correspondents/delete.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/correspondents/delete.ts)_
 
 ## `ppls correspondents list`
 
@@ -241,6 +281,42 @@ EXAMPLES
 
 _See code: [src/commands/custom-fields/add.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/custom-fields/add.ts)_
 
+## `ppls custom-fields delete ID`
+
+Delete a custom field
+
+```
+USAGE
+  $ ppls custom-fields delete ID [--date-format <value>] [--header <value>...] [--hostname <value>] [--plain | --json |
+    --table] [--sort <value>] [--token <value>] [-y]
+
+ARGUMENTS
+  ID  Custom field id
+
+FLAGS
+  -y, --yes           Skip confirmation prompt
+      --sort=<value>  Sort results by the provided field
+
+GLOBAL FLAGS
+  --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
+  --json                 Format output as json.
+  --plain                Format output as plain text.
+  --table                Format output as table.
+
+ENVIRONMENT FLAGS
+  --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
+  --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
+  --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+DESCRIPTION
+  Delete a custom field
+
+EXAMPLES
+  $ ppls custom-fields delete 123
+```
+
+_See code: [src/commands/custom-fields/delete.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/custom-fields/delete.ts)_
+
 ## `ppls custom-fields list`
 
 List custom fields
@@ -387,6 +463,42 @@ EXAMPLES
 ```
 
 _See code: [src/commands/document-types/add.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/document-types/add.ts)_
+
+## `ppls document-types delete ID`
+
+Delete a document type
+
+```
+USAGE
+  $ ppls document-types delete ID [--date-format <value>] [--header <value>...] [--hostname <value>] [--plain | --json |
+    --table] [--sort <value>] [--token <value>] [-y]
+
+ARGUMENTS
+  ID  Document type id
+
+FLAGS
+  -y, --yes           Skip confirmation prompt
+      --sort=<value>  Sort results by the provided field
+
+GLOBAL FLAGS
+  --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
+  --json                 Format output as json.
+  --plain                Format output as plain text.
+  --table                Format output as table.
+
+ENVIRONMENT FLAGS
+  --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
+  --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
+  --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+DESCRIPTION
+  Delete a document type
+
+EXAMPLES
+  $ ppls document-types delete 123
+```
+
+_See code: [src/commands/document-types/delete.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/document-types/delete.ts)_
 
 ## `ppls document-types list`
 
@@ -660,6 +772,42 @@ EXAMPLES
 ```
 
 _See code: [src/commands/tags/add.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/tags/add.ts)_
+
+## `ppls tags delete ID`
+
+Delete a tag
+
+```
+USAGE
+  $ ppls tags delete ID [--date-format <value>] [--header <value>...] [--hostname <value>] [--plain | --json |
+    --table] [--sort <value>] [--token <value>] [-y]
+
+ARGUMENTS
+  ID  Tag id
+
+FLAGS
+  -y, --yes           Skip confirmation prompt
+      --sort=<value>  Sort results by the provided field
+
+GLOBAL FLAGS
+  --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
+  --json                 Format output as json.
+  --plain                Format output as plain text.
+  --table                Format output as table.
+
+ENVIRONMENT FLAGS
+  --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
+  --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
+  --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+DESCRIPTION
+  Delete a tag
+
+EXAMPLES
+  $ ppls tags delete 123
+```
+
+_See code: [src/commands/tags/delete.ts](https://github.com/nickchristensen/ppls/blob/v0.0.0/src/commands/tags/delete.ts)_
 
 ## `ppls tags list`
 

--- a/src/commands/correspondents/delete.ts
+++ b/src/commands/correspondents/delete.ts
@@ -1,0 +1,22 @@
+import {Args, Flags} from '@oclif/core'
+
+import {DeleteCommand} from '../../delete-command.js'
+
+export default class CorrespondentsDelete extends DeleteCommand {
+  static override args = {
+    id: Args.integer({description: 'Correspondent id', required: true}),
+  }
+  static override description = 'Delete a correspondent'
+  static override examples = ['<%= config.bin %> <%= command.id %> 123']
+  static override flags = {
+    yes: Flags.boolean({char: 'y', description: 'Skip confirmation prompt'}),
+  }
+
+  protected deleteLabel(id: number | string): string {
+    return `correspondent ${id}`
+  }
+
+  protected deletePath(id: number | string): string {
+    return `/api/correspondents/${id}/`
+  }
+}

--- a/src/commands/custom-fields/delete.ts
+++ b/src/commands/custom-fields/delete.ts
@@ -1,0 +1,22 @@
+import {Args, Flags} from '@oclif/core'
+
+import {DeleteCommand} from '../../delete-command.js'
+
+export default class CustomFieldsDelete extends DeleteCommand {
+  static override args = {
+    id: Args.integer({description: 'Custom field id', required: true}),
+  }
+  static override description = 'Delete a custom field'
+  static override examples = ['<%= config.bin %> <%= command.id %> 123']
+  static override flags = {
+    yes: Flags.boolean({char: 'y', description: 'Skip confirmation prompt'}),
+  }
+
+  protected deleteLabel(id: number | string): string {
+    return `custom field ${id}`
+  }
+
+  protected deletePath(id: number | string): string {
+    return `/api/custom_fields/${id}/`
+  }
+}

--- a/src/commands/document-types/delete.ts
+++ b/src/commands/document-types/delete.ts
@@ -1,0 +1,22 @@
+import {Args, Flags} from '@oclif/core'
+
+import {DeleteCommand} from '../../delete-command.js'
+
+export default class DocumentTypesDelete extends DeleteCommand {
+  static override args = {
+    id: Args.integer({description: 'Document type id', required: true}),
+  }
+  static override description = 'Delete a document type'
+  static override examples = ['<%= config.bin %> <%= command.id %> 123']
+  static override flags = {
+    yes: Flags.boolean({char: 'y', description: 'Skip confirmation prompt'}),
+  }
+
+  protected deleteLabel(id: number | string): string {
+    return `document type ${id}`
+  }
+
+  protected deletePath(id: number | string): string {
+    return `/api/document_types/${id}/`
+  }
+}

--- a/src/commands/tags/delete.ts
+++ b/src/commands/tags/delete.ts
@@ -1,0 +1,22 @@
+import {Args, Flags} from '@oclif/core'
+
+import {DeleteCommand} from '../../delete-command.js'
+
+export default class TagsDelete extends DeleteCommand {
+  static override args = {
+    id: Args.integer({description: 'Tag id', required: true}),
+  }
+  static override description = 'Delete a tag'
+  static override examples = ['<%= config.bin %> <%= command.id %> 123']
+  static override flags = {
+    yes: Flags.boolean({char: 'y', description: 'Skip confirmation prompt'}),
+  }
+
+  protected deleteLabel(id: number | string): string {
+    return `tag ${id}`
+  }
+
+  protected deletePath(id: number | string): string {
+    return `/api/tags/${id}/`
+  }
+}

--- a/src/delete-command.ts
+++ b/src/delete-command.ts
@@ -1,0 +1,76 @@
+import {createInterface} from 'node:readline'
+
+import {BaseCommand} from './base-command.js'
+
+type DeleteCommandArgs = {
+  id: number | string
+}
+
+type DeleteCommandFlags = {
+  yes?: boolean
+}
+
+type DeleteCommandResult<TResponse> = null | TResponse | {deleted: true; id: number | string}
+
+export abstract class DeleteCommand<TResponse = unknown> extends BaseCommand {
+  protected deleteId(args: DeleteCommandArgs): number | string {
+    return args.id
+  }
+
+  protected abstract deleteLabel(id: number | string): string
+
+  protected deleteMessage(id: number | string, _result: null | TResponse): string | undefined {
+    return `Deleted ${this.deleteLabel(id)}`
+  }
+
+  protected abstract deletePath(id: number | string): string
+
+  protected async ensureConfirmed(flags: DeleteCommandFlags, id: number | string): Promise<void> {
+    if (flags.yes) {
+      return
+    }
+
+    if (!process.stdin.isTTY) {
+      this.error('Confirmation required. Re-run with --yes to proceed.')
+    }
+
+    const rl = createInterface({input: process.stdin, output: process.stdout})
+    const answer = await new Promise<string>((resolve) => {
+      rl.question(`Delete ${this.deleteLabel(id)}? (y/N) `, (response) => resolve(response))
+    })
+    rl.close()
+    const confirmed = ['y', 'yes'].includes(answer.trim().toLowerCase())
+
+    if (!confirmed) {
+      this.exit(0)
+    }
+  }
+
+  public async run(): Promise<DeleteCommandResult<TResponse>> {
+    const {args, flags, metadata} = await this.parse()
+    const resolvedFlags = await this.resolveGlobalFlags(flags, metadata)
+    const apiFlags = {
+      headers: resolvedFlags.headers,
+      hostname: resolvedFlags.hostname,
+      token: resolvedFlags.token,
+    }
+    const deleteFlags = flags as DeleteCommandFlags
+    const id = this.deleteId(args as DeleteCommandArgs)
+
+    await this.ensureConfirmed(deleteFlags, id)
+
+    const result = await this.deleteApiJson<TResponse>(apiFlags, this.deletePath(id))
+
+    if (this.jsonEnabled()) {
+      return result === null ? {deleted: true, id} : result
+    }
+
+    const message = this.deleteMessage(id, result)
+
+    if (message) {
+      this.log(message)
+    }
+
+    return result
+  }
+}

--- a/test/commands/correspondents/delete.test.ts
+++ b/test/commands/correspondents/delete.test.ts
@@ -1,0 +1,49 @@
+import {runCommand} from '@oclif/test'
+import {expect} from 'chai'
+
+describe('correspondents:delete', () => {
+  const originalEnv = {
+    hostname: process.env.PPLS_HOSTNAME,
+    token: process.env.PPLS_TOKEN,
+  }
+  const originalFetch = globalThis.fetch
+  let requests: string[] = []
+
+  beforeEach(() => {
+    process.env.PPLS_HOSTNAME = 'https://paperless.example.test'
+    process.env.PPLS_TOKEN = 'test-token'
+    requests = []
+  })
+
+  afterEach(() => {
+    if (originalEnv.hostname === undefined) {
+      delete process.env.PPLS_HOSTNAME
+    } else {
+      process.env.PPLS_HOSTNAME = originalEnv.hostname
+    }
+
+    if (originalEnv.token === undefined) {
+      delete process.env.PPLS_TOKEN
+    } else {
+      process.env.PPLS_TOKEN = originalEnv.token
+    }
+
+    globalThis.fetch = originalFetch
+  })
+
+  it('deletes a correspondent', async () => {
+    globalThis.fetch = async (input, init) => {
+      requests.push(String(input))
+      expect(init?.method).to.equal('DELETE')
+
+      return new Response(null, {
+        status: 204,
+      })
+    }
+
+    const {stdout} = await runCommand('correspondents:delete 12 --yes')
+
+    expect(stdout.trim()).to.equal('Deleted correspondent 12')
+    expect(new URL(requests[0]).pathname).to.equal('/api/correspondents/12/')
+  })
+})

--- a/test/commands/custom-fields/delete.test.ts
+++ b/test/commands/custom-fields/delete.test.ts
@@ -1,0 +1,49 @@
+import {runCommand} from '@oclif/test'
+import {expect} from 'chai'
+
+describe('custom-fields:delete', () => {
+  const originalEnv = {
+    hostname: process.env.PPLS_HOSTNAME,
+    token: process.env.PPLS_TOKEN,
+  }
+  const originalFetch = globalThis.fetch
+  let requests: string[] = []
+
+  beforeEach(() => {
+    process.env.PPLS_HOSTNAME = 'https://paperless.example.test'
+    process.env.PPLS_TOKEN = 'test-token'
+    requests = []
+  })
+
+  afterEach(() => {
+    if (originalEnv.hostname === undefined) {
+      delete process.env.PPLS_HOSTNAME
+    } else {
+      process.env.PPLS_HOSTNAME = originalEnv.hostname
+    }
+
+    if (originalEnv.token === undefined) {
+      delete process.env.PPLS_TOKEN
+    } else {
+      process.env.PPLS_TOKEN = originalEnv.token
+    }
+
+    globalThis.fetch = originalFetch
+  })
+
+  it('deletes a custom field', async () => {
+    globalThis.fetch = async (input, init) => {
+      requests.push(String(input))
+      expect(init?.method).to.equal('DELETE')
+
+      return new Response(null, {
+        status: 204,
+      })
+    }
+
+    const {stdout} = await runCommand('custom-fields:delete 9 --yes')
+
+    expect(stdout.trim()).to.equal('Deleted custom field 9')
+    expect(new URL(requests[0]).pathname).to.equal('/api/custom_fields/9/')
+  })
+})

--- a/test/commands/document-types/delete.test.ts
+++ b/test/commands/document-types/delete.test.ts
@@ -1,0 +1,49 @@
+import {runCommand} from '@oclif/test'
+import {expect} from 'chai'
+
+describe('document-types:delete', () => {
+  const originalEnv = {
+    hostname: process.env.PPLS_HOSTNAME,
+    token: process.env.PPLS_TOKEN,
+  }
+  const originalFetch = globalThis.fetch
+  let requests: string[] = []
+
+  beforeEach(() => {
+    process.env.PPLS_HOSTNAME = 'https://paperless.example.test'
+    process.env.PPLS_TOKEN = 'test-token'
+    requests = []
+  })
+
+  afterEach(() => {
+    if (originalEnv.hostname === undefined) {
+      delete process.env.PPLS_HOSTNAME
+    } else {
+      process.env.PPLS_HOSTNAME = originalEnv.hostname
+    }
+
+    if (originalEnv.token === undefined) {
+      delete process.env.PPLS_TOKEN
+    } else {
+      process.env.PPLS_TOKEN = originalEnv.token
+    }
+
+    globalThis.fetch = originalFetch
+  })
+
+  it('deletes a document type', async () => {
+    globalThis.fetch = async (input, init) => {
+      requests.push(String(input))
+      expect(init?.method).to.equal('DELETE')
+
+      return new Response(null, {
+        status: 204,
+      })
+    }
+
+    const {stdout} = await runCommand('document-types:delete 10 --yes')
+
+    expect(stdout.trim()).to.equal('Deleted document type 10')
+    expect(new URL(requests[0]).pathname).to.equal('/api/document_types/10/')
+  })
+})

--- a/test/commands/tags/delete.test.ts
+++ b/test/commands/tags/delete.test.ts
@@ -1,0 +1,49 @@
+import {runCommand} from '@oclif/test'
+import {expect} from 'chai'
+
+describe('tags:delete', () => {
+  const originalEnv = {
+    hostname: process.env.PPLS_HOSTNAME,
+    token: process.env.PPLS_TOKEN,
+  }
+  const originalFetch = globalThis.fetch
+  let requests: string[] = []
+
+  beforeEach(() => {
+    process.env.PPLS_HOSTNAME = 'https://paperless.example.test'
+    process.env.PPLS_TOKEN = 'test-token'
+    requests = []
+  })
+
+  afterEach(() => {
+    if (originalEnv.hostname === undefined) {
+      delete process.env.PPLS_HOSTNAME
+    } else {
+      process.env.PPLS_HOSTNAME = originalEnv.hostname
+    }
+
+    if (originalEnv.token === undefined) {
+      delete process.env.PPLS_TOKEN
+    } else {
+      process.env.PPLS_TOKEN = originalEnv.token
+    }
+
+    globalThis.fetch = originalFetch
+  })
+
+  it('deletes a tag', async () => {
+    globalThis.fetch = async (input, init) => {
+      requests.push(String(input))
+      expect(init?.method).to.equal('DELETE')
+
+      return new Response(null, {
+        status: 204,
+      })
+    }
+
+    const {stdout} = await runCommand('tags:delete 101 --yes')
+
+    expect(stdout.trim()).to.equal('Deleted tag 101')
+    expect(new URL(requests[0]).pathname).to.equal('/api/tags/101/')
+  })
+})


### PR DESCRIPTION
## Summary
- add a DeleteCommand base with confirmation and json fallback
- add delete commands/tests for correspondents, tags, document-types, and custom-fields
- extend the base API helper to handle empty DELETE responses

## Testing
- npm run test

Fixes #21

Co-authored-by: Codex <noreply@openai.com>