### PR TITLE
Add document list filters

### DIFF
--- a/.codex/skills/paperless-ngx-api/SKILL.md
+++ b/.codex/skills/paperless-ngx-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: paperless-ngx-api
-description: Use when working with the Paperless-ngx REST API: looking up endpoints, request/response shapes, auth requirements, filtering/pagination, or generating example requests/responses from the OpenAPI spec. Trigger for tasks involving Paperless-ngx API integrations, client code, curl examples, or schema details.
+description: Use when working with the Paperless-ngx REST API; looking up endpoints, request/response shapes, auth requirements, filtering/pagination, or generating example requests/responses from the OpenAPI spec. Trigger for tasks involving Paperless-ngx API integrations, client code, curl examples, or schema details.
 ---
 
 # Paperless Ngx Api
@@ -44,4 +44,5 @@ Common `yq` snippets (adjust selectors based on the spec structure):
 ## Resources
 
 ### references/
+
 - `paperless-ngx-rest-api.yaml` (OpenAPI spec)

--- a/README.md
+++ b/README.md
@@ -284,11 +284,9 @@ USAGE
     [--sort <value>]
 
 FLAGS
-  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
-  --name-contains=<value>  Filter by name substring
-  --page=<value>           Page number to fetch
-  --page-size=<value>      [default: disable pagination, all results] Number of results per page
-  --sort=<value>           Sort results by the provided field
+  --page=<value>       Page number to fetch
+  --page-size=<value>  [default: disable pagination, all results] Number of results per page
+  --sort=<value>       Sort results by the provided field
 
 GLOBAL FLAGS
   --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
@@ -300,6 +298,10 @@ ENVIRONMENT FLAGS
   --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
   --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
   --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+FILTER FLAGS
+  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
+  --name-contains=<value>  Filter by name substring
 
 DESCRIPTION
   List correspondents
@@ -461,11 +463,9 @@ USAGE
     [--sort <value>]
 
 FLAGS
-  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
-  --name-contains=<value>  Filter by name substring
-  --page=<value>           Page number to fetch
-  --page-size=<value>      [default: disable pagination, all results] Number of results per page
-  --sort=<value>           Sort results by the provided field
+  --page=<value>       Page number to fetch
+  --page-size=<value>  [default: disable pagination, all results] Number of results per page
+  --sort=<value>       Sort results by the provided field
 
 GLOBAL FLAGS
   --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
@@ -477,6 +477,10 @@ ENVIRONMENT FLAGS
   --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
   --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
   --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+FILTER FLAGS
+  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
+  --name-contains=<value>  Filter by name substring
 
 DESCRIPTION
   List custom fields
@@ -636,11 +640,9 @@ USAGE
     [--sort <value>]
 
 FLAGS
-  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
-  --name-contains=<value>  Filter by name substring
-  --page=<value>           Page number to fetch
-  --page-size=<value>      [default: disable pagination, all results] Number of results per page
-  --sort=<value>           Sort results by the provided field
+  --page=<value>       Page number to fetch
+  --page-size=<value>  [default: disable pagination, all results] Number of results per page
+  --sort=<value>       Sort results by the provided field
 
 GLOBAL FLAGS
   --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
@@ -652,6 +654,10 @@ ENVIRONMENT FLAGS
   --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
   --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
   --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+FILTER FLAGS
+  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
+  --name-contains=<value>  Filter by name substring
 
 DESCRIPTION
   List document types
@@ -854,15 +860,37 @@ List documents
 ```
 USAGE
   $ ppls documents list [--date-format <value>] [--header <value>...] [--hostname <value>] [--plain | --json |
-    --table] [--token <value>] [--id-in <value>... | --name-contains <value>] [--page <value> --page-size <value>]
-    [--sort <value>]
+    --table] [--token <value>] [--page <value> --page-size <value>] [--sort <value>] [--added-after YYYY-MM-DD|ISO-8601
+    | [--id-in <value>... | --name-contains <value>]] [--added-before YYYY-MM-DD|ISO-8601 | ] [--created-after
+    YYYY-MM-DD|ISO-8601 | ] [--created-before YYYY-MM-DD|ISO-8601 | ] [--modified-after YYYY-MM-DD|ISO-8601 | ]
+    [--modified-before YYYY-MM-DD|ISO-8601 | ] [--no-correspondent | [--correspondent <value>... | ] |
+    [--correspondent-not <value>... | ] | ] [--no-document-type | [--document-type <value>... | ] | [--document-type-not
+    <value>... | ] | ] [--no-tag | --tag <value>... | --tag-all <value>... | --tag-not <value>... | ]
 
 FLAGS
-  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
-  --name-contains=<value>  Filter by name substring
-  --page=<value>           Page number to fetch
-  --page-size=<value>      [default: disable pagination, all results] Number of results per page
-  --sort=<value>           Sort results by the provided field
+  --page=<value>       Page number to fetch
+  --page-size=<value>  [default: disable pagination, all results] Number of results per page
+  --sort=<value>       Sort results by the provided field
+
+FILTER FLAGS
+  --added-after=YYYY-MM-DD|ISO-8601      Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) >= value
+  --added-before=YYYY-MM-DD|ISO-8601     Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) <= value
+  --correspondent=<value>...             Filter by correspondent ids (repeatable or comma-separated)
+  --correspondent-not=<value>...         Exclude correspondent ids (repeatable or comma-separated)
+  --created-after=YYYY-MM-DD|ISO-8601    Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) >= value
+  --created-before=YYYY-MM-DD|ISO-8601   Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) <= value
+  --document-type=<value>...             Filter by document type ids (repeatable or comma-separated)
+  --document-type-not=<value>...         Exclude document type ids (repeatable or comma-separated)
+  --id-in=<value>...                     Filter by id list (repeatable or comma-separated)
+  --modified-after=YYYY-MM-DD|ISO-8601   Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) >= value
+  --modified-before=YYYY-MM-DD|ISO-8601  Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) <= value
+  --name-contains=<value>                Filter by name substring
+  --no-correspondent                     Filter documents with no correspondent
+  --no-document-type                     Filter documents with no document type
+  --no-tag                               Filter documents with no tags
+  --tag=<value>...                       Filter by tag ids (repeatable or comma-separated, OR)
+  --tag-all=<value>...                   Filter by tag ids (repeatable or comma-separated, AND)
+  --tag-not=<value>...                   Exclude tag ids (repeatable or comma-separated)
 
 GLOBAL FLAGS
   --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
@@ -1094,11 +1122,9 @@ USAGE
     [--sort <value>]
 
 FLAGS
-  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
-  --name-contains=<value>  Filter by name substring
-  --page=<value>           Page number to fetch
-  --page-size=<value>      [default: disable pagination, all results] Number of results per page
-  --sort=<value>           Sort results by the provided field
+  --page=<value>       Page number to fetch
+  --page-size=<value>  [default: disable pagination, all results] Number of results per page
+  --sort=<value>       Sort results by the provided field
 
 GLOBAL FLAGS
   --date-format=<value>  [default: yyyy-MM-dd, env: PPLS_DATE_FORMAT] Format output dates using a template.
@@ -1110,6 +1136,10 @@ ENVIRONMENT FLAGS
   --header=<value>...  [env: PPLS_HEADERS] Add a custom request header (repeatable, format: Key=Value)
   --hostname=<value>   [env: PPLS_HOSTNAME] Paperless-ngx base URL
   --token=<value>      [env: PPLS_TOKEN] Paperless-ngx API token
+
+FILTER FLAGS
+  --id-in=<value>...       Filter by id list (repeatable or comma-separated)
+  --name-contains=<value>  Filter by name substring
 
 DESCRIPTION
   List tags

--- a/src/base-command.ts
+++ b/src/base-command.ts
@@ -10,7 +10,7 @@ export type ApiFlags = {
   token: string
 }
 
-type QueryParams = Record<string, number | string | string[] | undefined>
+type QueryParams = Record<string, number | number[] | string | string[] | undefined>
 
 type ResolvedGlobalFlags = ApiFlags & {
   dateFormat: string

--- a/src/commands/documents/list.ts
+++ b/src/commands/documents/list.ts
@@ -1,21 +1,116 @@
 import type {Document} from '../../types/documents.js'
 
 import {ListCommand} from '../../list-command.js'
+import {isDateOnly} from '../../helpers/date-utils.js'
+import {dateLike} from '../../flags/date-like.js'
+
+type DocumentsListFlags = {
+  'added-after'?: string
+  'added-before'?: string
+  'created-after'?: string
+  'created-before'?: string
+  'modified-after'?: string
+  'modified-before'?: string
+}
+
+type DateRangeFields = {
+  after: string
+  before: string
+}
+
+type DateRangeFlagGroups = {
+  added: DateRangeFields
+  created: DateRangeFields
+  modified: DateRangeFields
+}
+
+const DATE_RANGE_FLAGS: DateRangeFlagGroups = {
+  added: {
+    after: 'added-after',
+    before: 'added-before',
+  },
+  created: {
+    after: 'created-after',
+    before: 'created-before',
+  },
+  modified: {
+    after: 'modified-after',
+    before: 'modified-before',
+  },
+}
+
+const addDateRangeParams = (
+  params: Record<string, number | string | string[] | undefined>,
+  field: keyof DateRangeFlagGroups,
+  flags: DocumentsListFlags,
+): void => {
+  const {after, before} = DATE_RANGE_FLAGS[field]
+  const afterValue = flags[after]
+  const beforeValue = flags[before]
+
+  if (afterValue) {
+    const key = isDateOnly(afterValue) ? `${field}__date__gte` : `${field}__gte`
+    params[key] = afterValue
+  }
+
+  if (beforeValue) {
+    const key = isDateOnly(beforeValue) ? `${field}__date__lte` : `${field}__lte`
+    params[key] = beforeValue
+  }
+}
 
 export default class DocumentsList extends ListCommand<Document> {
   static override description = 'List documents'
   static override examples = ['<%= config.bin %> <%= command.id %>']
+  static override flags = {
+    ...ListCommand.baseFlags,
+    'added-after': dateLike({
+      description: 'Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+    }),
+    'added-before': dateLike({
+      description: 'Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+    }),
+    'created-after': dateLike({
+      description: 'Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+    }),
+    'created-before': dateLike({
+      description: 'Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+    }),
+    'modified-after': dateLike({
+      description: 'Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+    }),
+    'modified-before': dateLike({
+      description: 'Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+    }),
+  }
   protected listPath = '/api/documents/'
   protected tableAttrs = ['id', 'title', 'created', 'added', 'correspondent', 'document_type', 'tags']
+
+  protected override extraListFlags(flags: Record<string, unknown>): Record<string, unknown> {
+    const typedFlags = flags as DocumentsListFlags
+
+    return {
+      'added-after': typedFlags['added-after'],
+      'added-before': typedFlags['added-before'],
+      'created-after': typedFlags['created-after'],
+      'created-before': typedFlags['created-before'],
+      'modified-after': typedFlags['modified-after'],
+      'modified-before': typedFlags['modified-before'],
+    }
+  }
 
   protected override listParams(
     flags: Parameters<ListCommand['listParams']>[0],
   ): Record<string, number | string | string[] | undefined> {
+    const typedFlags = flags as Parameters<ListCommand['listParams']>[0] & DocumentsListFlags
     const params = super.listParams(flags)
 
     delete params.name__icontains
     // eslint-disable-next-line camelcase -- API uses double-underscore field names.
     params.title__icontains = flags['name-contains']
+    addDateRangeParams(params, 'added', typedFlags)
+    addDateRangeParams(params, 'created', typedFlags)
+    addDateRangeParams(params, 'modified', typedFlags)
 
     return params
   }

--- a/src/commands/documents/list.ts
+++ b/src/commands/documents/list.ts
@@ -1,16 +1,28 @@
+import {Flags} from '@oclif/core'
+
 import type {Document} from '../../types/documents.js'
 
-import {ListCommand} from '../../list-command.js'
-import {isDateOnly} from '../../helpers/date-utils.js'
 import {dateLike} from '../../flags/date-like.js'
+import {isDateOnly} from '../../helpers/date-utils.js'
+import {ListCommand} from '../../list-command.js'
 
 type DocumentsListFlags = {
   'added-after'?: string
   'added-before'?: string
+  correspondent?: number[]
+  'correspondent-not'?: number[]
   'created-after'?: string
   'created-before'?: string
+  'document-type'?: number[]
+  'document-type-not'?: number[]
   'modified-after'?: string
   'modified-before'?: string
+  'no-correspondent'?: boolean
+  'no-document-type'?: boolean
+  'no-tag'?: boolean
+  tag?: number[]
+  'tag-all'?: number[]
+  'tag-not'?: number[]
 }
 
 type DateRangeFields = {
@@ -24,7 +36,7 @@ type DateRangeFlagGroups = {
   modified: DateRangeFields
 }
 
-const DATE_RANGE_FLAGS: DateRangeFlagGroups = {
+const DATE_RANGE_FLAGS = {
   added: {
     after: 'added-after',
     before: 'added-before',
@@ -37,16 +49,19 @@ const DATE_RANGE_FLAGS: DateRangeFlagGroups = {
     after: 'modified-after',
     before: 'modified-before',
   },
-}
+} as const satisfies DateRangeFlagGroups
+
+type DateRangeFlagName = (typeof DATE_RANGE_FLAGS)[keyof typeof DATE_RANGE_FLAGS]['after' | 'before']
 
 const addDateRangeParams = (
-  params: Record<string, number | string | string[] | undefined>,
+  params: Record<string, number | number[] | string | string[] | undefined>,
   field: keyof DateRangeFlagGroups,
   flags: DocumentsListFlags,
 ): void => {
   const {after, before} = DATE_RANGE_FLAGS[field]
-  const afterValue = flags[after]
-  const beforeValue = flags[before]
+  const typedFlags = flags as Record<DateRangeFlagName, string | undefined>
+  const afterValue = typedFlags[after]
+  const beforeValue = typedFlags[before]
 
   if (afterValue) {
     const key = isDateOnly(afterValue) ? `${field}__date__gte` : `${field}__gte`
@@ -66,21 +81,97 @@ export default class DocumentsList extends ListCommand<Document> {
     ...ListCommand.baseFlags,
     'added-after': dateLike({
       description: 'Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
     }),
     'added-before': dateLike({
       description: 'Filter by added date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+    }),
+    correspondent: Flags.integer({
+      delimiter: ',',
+      description: 'Filter by correspondent ids (repeatable or comma-separated)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
+    }),
+    'correspondent-not': Flags.integer({
+      delimiter: ',',
+      description: 'Exclude correspondent ids (repeatable or comma-separated)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
     }),
     'created-after': dateLike({
       description: 'Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
     }),
     'created-before': dateLike({
       description: 'Filter by created date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+    }),
+    'document-type': Flags.integer({
+      delimiter: ',',
+      description: 'Filter by document type ids (repeatable or comma-separated)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
+    }),
+    'document-type-not': Flags.integer({
+      delimiter: ',',
+      description: 'Exclude document type ids (repeatable or comma-separated)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
     }),
     'modified-after': dateLike({
       description: 'Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) >= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
     }),
     'modified-before': dateLike({
       description: 'Filter by modified date (YYYY-MM-DD) or datetime (ISO 8601) <= value',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+    }),
+    'no-correspondent': Flags.boolean({
+      description: 'Filter documents with no correspondent',
+      exclusive: ['correspondent', 'correspondent-not', 'id-in'],
+      helpGroup: 'FILTER',
+    }),
+    'no-document-type': Flags.boolean({
+      description: 'Filter documents with no document type',
+      exclusive: ['document-type', 'document-type-not', 'id-in'],
+      helpGroup: 'FILTER',
+    }),
+    'no-tag': Flags.boolean({
+      description: 'Filter documents with no tags',
+      exclusive: ['tag', 'tag-all', 'tag-not', 'id-in'],
+      helpGroup: 'FILTER',
+    }),
+    tag: Flags.integer({
+      delimiter: ',',
+      description: 'Filter by tag ids (repeatable or comma-separated, OR)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
+    }),
+    'tag-all': Flags.integer({
+      delimiter: ',',
+      description: 'Filter by tag ids (repeatable or comma-separated, AND)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
+    }),
+    'tag-not': Flags.integer({
+      delimiter: ',',
+      description: 'Exclude tag ids (repeatable or comma-separated)',
+      exclusive: ['id-in'],
+      helpGroup: 'FILTER',
+      multiple: true,
     }),
   }
   protected listPath = '/api/documents/'
@@ -92,22 +183,43 @@ export default class DocumentsList extends ListCommand<Document> {
     return {
       'added-after': typedFlags['added-after'],
       'added-before': typedFlags['added-before'],
+      correspondent: typedFlags.correspondent,
+      'correspondent-not': typedFlags['correspondent-not'],
       'created-after': typedFlags['created-after'],
       'created-before': typedFlags['created-before'],
+      'document-type': typedFlags['document-type'],
+      'document-type-not': typedFlags['document-type-not'],
       'modified-after': typedFlags['modified-after'],
       'modified-before': typedFlags['modified-before'],
+      'no-correspondent': typedFlags['no-correspondent'],
+      'no-document-type': typedFlags['no-document-type'],
+      'no-tag': typedFlags['no-tag'],
+      tag: typedFlags.tag,
+      'tag-all': typedFlags['tag-all'],
+      'tag-not': typedFlags['tag-not'],
     }
   }
 
   protected override listParams(
     flags: Parameters<ListCommand['listParams']>[0],
-  ): Record<string, number | string | string[] | undefined> {
-    const typedFlags = flags as Parameters<ListCommand['listParams']>[0] & DocumentsListFlags
+  ): Record<string, number | number[] | string | string[] | undefined> {
+    const typedFlags = flags as DocumentsListFlags & Parameters<ListCommand['listParams']>[0]
     const params = super.listParams(flags)
 
     delete params.name__icontains
-    // eslint-disable-next-line camelcase -- API uses double-underscore field names.
+    /* eslint-disable camelcase -- API uses double-underscore field names. */
     params.title__icontains = flags['name-contains']
+    params.tags__id__in = typedFlags.tag
+    params.tags__id__all = typedFlags['tag-all']
+    params.tags__id__none = typedFlags['tag-not']
+    params.is_tagged = typedFlags['no-tag'] ? 'false' : undefined
+    params.correspondent__id__in = typedFlags.correspondent
+    params.correspondent__id__none = typedFlags['correspondent-not']
+    params.correspondent__isnull = typedFlags['no-correspondent'] ? 'true' : undefined
+    params.document_type__id__in = typedFlags['document-type']
+    params.document_type__id__none = typedFlags['document-type-not']
+    params.document_type__isnull = typedFlags['no-document-type'] ? 'true' : undefined
+    /* eslint-enable camelcase */
     addDateRangeParams(params, 'added', typedFlags)
     addDateRangeParams(params, 'created', typedFlags)
     addDateRangeParams(params, 'modified', typedFlags)

--- a/src/flags/date-like.ts
+++ b/src/flags/date-like.ts
@@ -4,7 +4,7 @@ import {isDateOnly, isDateTime} from '../helpers/date-utils.js'
 
 export const dateLike = Flags.custom<string>({
   helpValue: 'YYYY-MM-DD|ISO-8601',
-  parse: async (input: string): Promise<string> => {
+  async parse(input: string): Promise<string> {
     if (isDateOnly(input) || isDateTime(input)) {
       return input
     }

--- a/src/flags/date-like.ts
+++ b/src/flags/date-like.ts
@@ -1,0 +1,14 @@
+import {Flags} from '@oclif/core'
+
+import {isDateOnly, isDateTime} from '../helpers/date-utils.js'
+
+export const dateLike = Flags.custom<string>({
+  helpValue: 'YYYY-MM-DD|ISO-8601',
+  parse: async (input: string): Promise<string> => {
+    if (isDateOnly(input) || isDateTime(input)) {
+      return input
+    }
+
+    throw new Error('Use YYYY-MM-DD or an ISO 8601 datetime.')
+  },
+})

--- a/src/list-command.ts
+++ b/src/list-command.ts
@@ -35,11 +35,13 @@ export abstract class ListCommand<
       delimiter: ',',
       description: 'Filter by id list (repeatable or comma-separated)',
       exclusive: ['name-contains'],
+      helpGroup: 'FILTER',
       multiple: true,
     }),
     'name-contains': Flags.string({
       description: 'Filter by name substring',
       exclusive: ['id-in'],
+      helpGroup: 'FILTER',
     }),
     page: Flags.integer({
       dependsOn: ['page-size'],
@@ -63,7 +65,7 @@ export abstract class ListCommand<
 
   protected async fetchListResults<T>(options: {
     flags: ListCommandFlags
-    params?: Record<string, number | string | string[] | undefined>
+    params?: Record<string, number | number[] | string | string[] | undefined>
     path: string
   }): Promise<T[]> {
     const {flags, params = {}, path} = options
@@ -85,7 +87,7 @@ export abstract class ListCommand<
     }
   }
 
-  protected listParams(flags: ListCommandFlags): Record<string, number | string | string[] | undefined> {
+  protected listParams(flags: ListCommandFlags): Record<string, number | number[] | string | string[] | undefined> {
     return {
       'id__in': flags['id-in'],
       'name__icontains': flags['name-contains'],
@@ -168,7 +170,7 @@ export abstract class ListCommand<
 
   private buildListUrl(options: {
     flags: ListCommandFlags
-    params?: Record<string, number | string | string[] | undefined>
+    params?: Record<string, number | number[] | string | string[] | undefined>
     path: string
   }): URL {
     const {flags, params = {}, path} = options

--- a/src/list-command.ts
+++ b/src/list-command.ts
@@ -57,6 +57,10 @@ export abstract class ListCommand<
   protected abstract listPath: string
   protected abstract tableAttrs: TableColumnInput[]
 
+  protected extraListFlags(_flags: Record<string, unknown>): Record<string, unknown> {
+    return {}
+  }
+
   protected async fetchListResults<T>(options: {
     flags: ListCommandFlags
     params?: Record<string, number | string | string[] | undefined>
@@ -122,7 +126,7 @@ export abstract class ListCommand<
     const {flags, metadata} = await this.parse()
     const {dateFormat, ...apiFlags} = await this.resolveGlobalFlags(flags, metadata)
 
-    const listFlags: ListCommandFlags = {
+    const listFlags: ListCommandFlags & Record<string, unknown> = {
       headers: apiFlags.headers,
       hostname: apiFlags.hostname,
       'id-in': flags['id-in'],
@@ -131,6 +135,7 @@ export abstract class ListCommand<
       'page-size': flags['page-size'],
       sort: flags.sort,
       token: apiFlags.token,
+      ...this.extraListFlags(flags),
     }
     const outputFlags: ListOutputFlags = {
       ...listFlags,

--- a/test/commands/documents/list.test.ts
+++ b/test/commands/documents/list.test.ts
@@ -129,6 +129,192 @@ describe('documents:list', () => {
     expect(requestUrl.searchParams.get('title__icontains')).to.equal('BFPR100')
   })
 
+  it('supports added/created/modified date filters', async () => {
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(
+        JSON.stringify({
+          next: null,
+          results: [],
+        }),
+        {
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+        },
+      )
+    }
+
+    await runCommand([
+      'documents:list',
+      '--added-after',
+      '2024-01-01',
+      '--added-before',
+      '2024-01-31',
+      '--created-after',
+      '2024-02-01T02:03:04Z',
+      '--created-before',
+      '2024-02-28T00:00:00Z',
+      '--modified-after',
+      '2024-03-01',
+      '--modified-before',
+      '2024-03-31T23:59:59Z',
+    ])
+
+    const requestUrl = new URL(requests[0])
+    expect(requestUrl.searchParams.get('added__date__gte')).to.equal('2024-01-01')
+    expect(requestUrl.searchParams.get('added__date__lte')).to.equal('2024-01-31')
+    expect(requestUrl.searchParams.get('created__gte')).to.equal('2024-02-01T02:03:04Z')
+    expect(requestUrl.searchParams.get('created__lte')).to.equal('2024-02-28T00:00:00Z')
+    expect(requestUrl.searchParams.get('modified__date__gte')).to.equal('2024-03-01')
+    expect(requestUrl.searchParams.get('modified__lte')).to.equal('2024-03-31T23:59:59Z')
+  })
+
+  it('supports tag filters', async () => {
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(
+        JSON.stringify({
+          next: null,
+          results: [],
+        }),
+        {
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+        },
+      )
+    }
+
+    await runCommand('documents:list --tag 1,2 --tag-all 3,4 --tag-not 5')
+    const requestUrl = new URL(requests[0])
+
+    expect(requestUrl.searchParams.get('tags__id__in')).to.equal('1,2')
+    expect(requestUrl.searchParams.get('tags__id__all')).to.equal('3,4')
+    expect(requestUrl.searchParams.get('tags__id__none')).to.equal('5')
+  })
+
+  it('supports no-tag filtering', async () => {
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(
+        JSON.stringify({
+          next: null,
+          results: [],
+        }),
+        {
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+        },
+      )
+    }
+
+    await runCommand('documents:list --no-tag')
+    const requestUrl = new URL(requests[0])
+    expect(requestUrl.searchParams.get('is_tagged')).to.equal('false')
+  })
+
+  it('supports correspondent and document type filters', async () => {
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(
+        JSON.stringify({
+          next: null,
+          results: [],
+        }),
+        {
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+        },
+      )
+    }
+
+    await runCommand(
+      'documents:list --correspondent 12,13 --correspondent-not 8 --document-type 4,5 --document-type-not 6',
+    )
+    const requestUrl = new URL(requests[0])
+
+    expect(requestUrl.searchParams.get('correspondent__id__in')).to.equal('12,13')
+    expect(requestUrl.searchParams.get('correspondent__id__none')).to.equal('8')
+    expect(requestUrl.searchParams.get('document_type__id__in')).to.equal('4,5')
+    expect(requestUrl.searchParams.get('document_type__id__none')).to.equal('6')
+  })
+
+  it('supports no-correspondent and no-document-type filters', async () => {
+    globalThis.fetch = async (input) => {
+      requests.push(String(input))
+      return new Response(
+        JSON.stringify({
+          next: null,
+          results: [],
+        }),
+        {
+          headers: {'Content-Type': 'application/json'},
+          status: 200,
+        },
+      )
+    }
+
+    await runCommand('documents:list --no-correspondent --no-document-type')
+    const requestUrl = new URL(requests[0])
+
+    expect(requestUrl.searchParams.get('correspondent__isnull')).to.equal('true')
+    expect(requestUrl.searchParams.get('document_type__isnull')).to.equal('true')
+  })
+
+  it('rejects invalid date filters', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('Unexpected fetch call')
+    }
+
+    const {error} = await runCommand('documents:list --added-after not-a-date')
+
+    expect(error).to.be.instanceOf(Error)
+    expect(error?.message).to.match(/YYYY-MM-DD|ISO 8601/i)
+  })
+
+  it('rejects id-in with tag filters', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('Unexpected fetch call')
+    }
+
+    const {error} = await runCommand('documents:list --id-in 1,2 --tag 3')
+
+    expect(error).to.be.instanceOf(Error)
+    expect(error?.message).to.contain('cannot also be provided')
+  })
+
+  it('rejects no-tag with tag filters', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('Unexpected fetch call')
+    }
+
+    const {error} = await runCommand('documents:list --no-tag --tag 1')
+
+    expect(error).to.be.instanceOf(Error)
+    expect(error?.message).to.contain('cannot also be provided')
+  })
+
+  it('rejects no-correspondent with correspondent filters', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('Unexpected fetch call')
+    }
+
+    const {error} = await runCommand('documents:list --no-correspondent --correspondent 1')
+
+    expect(error).to.be.instanceOf(Error)
+    expect(error?.message).to.contain('cannot also be provided')
+  })
+
+  it('rejects no-document-type with document type filters', async () => {
+    globalThis.fetch = async () => {
+      throw new Error('Unexpected fetch call')
+    }
+
+    const {error} = await runCommand('documents:list --no-document-type --document-type 1')
+
+    expect(error).to.be.instanceOf(Error)
+    expect(error?.message).to.contain('cannot also be provided')
+  })
+
   it('respects page size overrides', async () => {
     globalThis.fetch = async (input) => {
       requests.push(String(input))


### PR DESCRIPTION
Summary:
- Add document list filters for tags, correspondents, and document types with include/exclude/no variants.
- Add date range filters (added/created/modified) with date-like parsing and shared validation.
- Add filter flag help grouping and exclusivity rules around id-in and no-* flags.
- Expand query param typing to support number arrays.
- Add comprehensive documents:list filter tests.

Filters added:
- Tags: --tag, --tag-all, --tag-not, --no-tag
- Correspondents: --correspondent, --correspondent-not, --no-correspondent
- Document types: --document-type, --document-type-not, --no-document-type
- Dates: --added-after/--added-before, --created-after/--created-before, --modified-after/--modified-before
- Global list filters used: --id-in (exclusive with all document filters), --name-contains